### PR TITLE
pycparser 2.21

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,19 @@ requirements:
     - pip
     - python
     - setuptools
+    - wheel
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:
     - pycparser
     - pycparser.ply
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    - pip check
 
 about:
   home: https://github.com/eliben/pycparser

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,13 +37,15 @@ test:
 
 about:
   home: https://github.com/eliben/pycparser
-  license: BSD 3-clause
+  license: BSD-3-clause
+  license_family: BSD
   license_file: LICENSE
   summary: Complete C99 parser in pure Python
   description: |
     pycparser is a complete parser of the C language, written in pure Python using the PLY parsing library.
     It parses C code into an AST and can serve as a front-end for C compilers or analysis tools.
   dev_url: https://github.com/eliben/pycparser
+  doc_url: https://github.com/eliben/pycparser/blob/master/README.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pycparser" %}
-{% set version = "2.20" %}
-{% set sha256 = "2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0" %}
+{% set version = "2.21" %}
+{% set sha256 = "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   noarch: python
   number: 0
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . -vvv
 
 requirements:


### PR DESCRIPTION
Update pycparser to 2.21

Version change: bump version number from 2.20 to 2.21
Bug Tracker: new open issues https://github.com/eliben/pycparser/issues
Github releases:  https://github.com/eliben/pycparser/releases
Upstream license:  https://github.com/eliben/pycparser/blob/master/LICENSE
Upstream Changelog: https://github.com/eliben/pycparser/blob/master/CHANGES
Upstream setup.py: https://github.com/eliben/pycparser/blob/release_v2.21/setup.py

The package pycparser is mentioned inside the packages:
cffi | docker-py

Actions:
1. Add `wheel`
2. Add test/requires & commands: `pip check`
3. Add `python <3.10` in test/requires
4. Add license_family
5. Add doc_url

Result:
- all-succeeded (except arm64)
