### PR TITLE
pycparser 2.22 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pycparser" %}
-{% set version = "2.21" %}
-{% set sha256 = "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206" %}
+{% set version = "2.22" %}
+{% set sha256 = "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vvv
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,8 @@ test:
     - tests
     # used by tests
     - examples  # [linux]
-    # contains fake libc includes which bypasses errors which occurs when including real system headers
+    # folder contains fake libc includes used by tests, which bypasses errors that would
+    # occurs if the system's regular stdlib headers were to be included and parsed.
     - utils  # [linux]
   imports:
     - pycparser

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -vv tests
+    - pytest --rootdir=. -vv tests
 
 about:
   home: https://github.com/eliben/pycparser

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ test:
     - pycparser.ply
   requires:
     - pip
-    - python <3.10
+    - python
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,8 @@ requirements:
 test:
   source_files:
     - tests
+    # used by tests
+    - examples  # [linux]
   imports:
     - pycparser
     - pycparser.ply

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: true  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ test:
     - tests
     # used by tests
     - examples  # [linux]
+    # contains fake libc includes which bypasses errors which occurs when including real system headers
+    - utils  # [linux]
   imports:
     - pycparser
     - pycparser.ply

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ about:
     pycparser is a complete parser of the C language, written in pure Python using the PLY parsing library.
     It parses C code into an AST and can serve as a front-end for C compilers or analysis tools.
   dev_url: https://github.com/eliben/pycparser
-  doc_url: https://github.com/eliben/pycparser/blob/master/README.rst
+  doc_url: https://github.com/eliben/pycparser
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,15 +24,19 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - pycparser
     - pycparser.ply
   requires:
     - pip
     - python
+    - pytest
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -vv tests
 
 about:
   home: https://github.com/eliben/pycparser

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "pycparser" %}
 {% set version = "2.22" %}
-{% set sha256 = "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6
 
 build:
-  noarch: python
   number: 0
   skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
 
 about:
   home: https://github.com/eliben/pycparser
-  license: BSD-3-clause
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: Complete C99 parser in pure Python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
     - python <3.10
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
 
 about:
   home: https://github.com/eliben/pycparser


### PR DESCRIPTION
pycparser 2.22 

**Destination channel:** Defaults

### Links

- [PKG-9410]
- dev_url:        https://github.com/eliben/pycparser/tree/release_v2.22
- conda_forge:    https://github.com/conda-forge/pycparser-feedstock
- pypi:           https://pypi.org/project/pycparser/2.22
- pypi inspector: https://inspector.pypi.io/project/pycparser/2.22

### Explanation of changes:

- new version number


[PKG-9410]: https://anaconda.atlassian.net/browse/PKG-9410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ