### PR TITLE
pycparser 2.23 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "pycparser" %}
-{% set version = "2.22" %}
+{% set version = "2.23" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2
 
 build:
   number: 0
@@ -19,7 +19,6 @@ requirements:
     - pip
     - python
     - setuptools
-    - wheel
   run:
     - python
 


### PR DESCRIPTION
pycparser 2.23 

**Destination channel:** Defaults

### Links

- [PKG-9609]
- dev_url:        https://github.com/eliben/pycparser/tree/release_v2.23
- conda_forge:    https://github.com/conda-forge/pycparser-feedstock
- pypi:           https://pypi.org/project/pycparser/2.23
- pypi inspector: https://inspector.pypi.io/project/pycparser/2.23

### Explanation of changes:

- new version number


[PKG-9609]: https://anaconda.atlassian.net/browse/PKG-9609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ